### PR TITLE
Use latest ipmitool package version from trusty/universe sources list

### DIFF
--- a/vars/basefs.yml
+++ b/vars/basefs.yml
@@ -11,7 +11,7 @@ basefs_exclude_packages: "initramfs-tools,initramfs-tools-bin,busybox-initramfs,
 
 basefs_package_manifest:
   - { package: "openssh-server",  version: "1:6.6p1-2ubuntu2.3" }
-  - { package: "ipmitool",        version: "1.8.13-1ubuntu0.5" }
+  - { package: "ipmitool",        version: "1.8.13-1" }
   - { package: "curl",            version: "7.35.0-1ubuntu2.5" }
   - { package: "vim-tiny",        version: "2:7.4.052-1ubuntu3" }
   - { package: "less",            version: "458-2" }


### PR DESCRIPTION
The ubuntu version isn't always found, sometimes it wants 0.3, sometimes 0.5. Try to fix this by just not using it.
