### PR TITLE
workaround that resolves https://github.com/RackHD/RackHD/issues/45

### DIFF
--- a/common/initrd_wrapper.yml
+++ b/common/initrd_wrapper.yml
@@ -12,7 +12,7 @@
   vars_files:
     - ../{{ config_file }}
   roles:
-    - ../{{ provisioner }}
+    - ../roles/initrd/provision_initrd
     - ../roles/initrd/build_initrd
 
 - hosts: build_local


### PR DESCRIPTION
@benbp I wasn't sure how this was all originally set up, but the redirect to load a dynamic provisioner certainly seemed to be failing per @larry-dean bug at https://github.com/RackHD/RackHD/issues/45

I dug out the relevant "provisioner" and replaced it into this role directly as a workaround, so I'm not sure how it works on other platforms - does this redirect using an ansible `{{ provisioner }}` variable interpolation normally function correctly? 
