### PR TITLE
Support the latest Ansible version 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_script:
 - sed -i '24,25 s/^/#/' vars/basefs.yml
 - sudo apt-add-repository -y ppa:ansible/ansible
 - sudo apt-get update -q
-- sudo apt-get install -y -q ansible=1.5.4+dfsg-1 
+- sudo apt-get install -y -q ansible
 - sudo modprobe overlayfs
 script:
 - sudo ansible-playbook -i hosts all.yml

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Requirements
 ---------------
 
 - Any Debian/Ubuntu based system (support for other distributions coming soon, theoretically though, just install debootstrap and it should work)
-- ansible version 1.5.4 is installed (`apt-get install ansible=1.5.4+dfsg-1`)
+- Ansible is installed (`apt-get install ansible` or `pip install ansible`)
 - Internet access OR network access to an apt cache/proxy server from the build machine
 
 <br>
@@ -75,6 +75,10 @@ use the default one. For example, to build the default images:
 ```
 sudo ansible-playbook -i hosts all.yml
 ```
+
+**All ansible runs must be done on the host machine that is building the images.** This is because we use
+the ansible_chroot connection type, which is not supported over ssh connections.
+
 - Note: OEM role provision_raid_overlay requires storcli_1.17.08_all.deb being copied into
   common/files. User can download it from http://docs.avagotech.com/docs/1.17.08_StorCLI.zip.
 
@@ -82,13 +86,13 @@ sudo ansible-playbook -i hosts all.yml
 
 The provisioner role is what specifies how the filesystem of an initrd, base
 image or overlay should be customized. To add a new provisioner, do the following.
-If you are familiar with Ansible, some of these steps will be obvious:
+If you have experience with Ansible, some of these steps will be familiar:
 
 - Make a new directory in `roles/<initrd|basefs|overlay>/tasks`, depending on the image type
 - Create and edit a main.yml file in the above directory to do the tasks you
   want (see [ansible modules](http://docs.ansible.com/ansible/modules_intro.html)
   if new to Ansible)
-- Add a new config_file into the vars directory. This will be included in the
+- Add a new config yaml file into the vars directory. This will be included in the
   Ansible run as a set of top-level variables (via vars_files) to be included/used
   by tasks in the role.
   *The config_file must have as a bare minimum a provisioner variable that points to the role, e.g.*
@@ -97,12 +101,13 @@ If you are familiar with Ansible, some of these steps will be obvious:
     provisioner: roles/overlay/provision_discovery_overlay
     ```
 - Configure a new playbook (see example.yml) to run the appropriate wrapper
-  playbook with the config_file, for example:
+  playbook with the config file and the provisioner role specified as vars, for example:
 
     ```
     - include: common/overlay_wrapper.yml
       vars:
         - config_file: vars/my_overlay.yml
+        - provisioner: <path to role directory, e.g. roles/overlay/provision_discovery_overlay>
     ```
   The wrapper playbooks handle all the setup and cleanup required to run a
   provisioner, such as filesystem mounting and creation, and build file creation.

--- a/all.yml
+++ b/all.yml
@@ -2,14 +2,17 @@
 - include: common/initrd_wrapper.yml
   vars:
     - config_file: vars/initrd.yml
+    - provisioner: roles/initrd/provision_initrd
 
 - include: common/basefs_wrapper.yml
   vars:
     - config_file: vars/basefs.yml
+    - provisioner: roles/basefs/provision_rootfs
 
 - include: common/overlay_wrapper.yml
   vars:
     - config_file: vars/discovery_overlay.yml
+    - provisioner: roles/overlay/provision_discovery_overlay
 
 - include: common/ipxe_builder.yml
   vars:

--- a/oem.yml
+++ b/oem.yml
@@ -2,7 +2,9 @@
 - include: common/overlay_wrapper.yml
   vars:
     - config_file: vars/oem/intel.yml
+    - provisioner: roles/oem/overlay/provision_intel_flashing_overlay
 
 - include: common/overlay_wrapper.yml
   vars:
     - config_file: vars/oem/quanta.yml
+    - provisioner: roles/oem/overlay/provision_quanta_flashing_overlay

--- a/vars/basefs.yml
+++ b/vars/basefs.yml
@@ -1,4 +1,4 @@
-provisioner: roles/basefs/provision_rootfs
+# provisioner: roles/basefs/provision_rootfs
 
 build_root: '{{ basefs_build_root }}'
 build_root_size: 1000m

--- a/vars/discovery_overlay.yml
+++ b/vars/discovery_overlay.yml
@@ -1,4 +1,4 @@
-provisioner: roles/overlay/provision_discovery_overlay
+# provisioner: roles/overlay/provision_discovery_overlay
 
 overlayfs_archive_name: "discovery.overlay.cpio"
 

--- a/vars/initrd.yml
+++ b/vars/initrd.yml
@@ -1,4 +1,4 @@
-provisioner: roles/initrd/provision_initrd
+# provisioner: roles/initrd/provision_initrd
 
 initrd_kernel_version: '{{ ubuntu_kernel_version }}'
 

--- a/vars/oem/intel.yml
+++ b/vars/oem/intel.yml
@@ -1,4 +1,4 @@
-provisioner: roles/oem/overlay/provision_intel_flashing_overlay
+# provisioner: roles/oem/overlay/provision_intel_flashing_overlay
 
 overlayfs_archive_name: "flash_intel.overlay.cpio"
 

--- a/vars/oem/quanta.yml
+++ b/vars/oem/quanta.yml
@@ -1,3 +1,3 @@
-provisioner: roles/oem/overlay/provision_quanta_flashing_overlay
+# provisioner: roles/oem/overlay/provision_quanta_flashing_overlay
 
 overlayfs_archive_name: "flash_quanta.overlay.cpio"

--- a/vars/oem/raid_overlay.yml
+++ b/vars/oem/raid_overlay.yml
@@ -1,4 +1,4 @@
-provisioner: roles/oem/overlay/provision_raid_overlay
+# provisioner: roles/oem/overlay/provision_raid_overlay
 
 overlayfs_archive_name: "raid.overlay.cpio"
 


### PR DESCRIPTION
After v1.5, using dynamic roles specified in a dynamic vars file no longer renders during playbook evaluation, so specify provisioners in the vars section instead.

Update the README to hopefully clear up minor confusions/pain points. General feedback on how the README could be improved is also welcome.

@heckj @larry-dean @jlongever @king-jam 

Fixes https://github.com/RackHD/RackHD/issues/45
