### PR TITLE
Add linux-image-extras package to initrd build environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,8 @@ before_script:
 # Rollback to 3.13 until initrd boot issue has been resolved
 - sed -i 's/3.16.0-25-generic/3.13.0-32-generic/g' group_vars/on_imagebuild
 - sed -i '24,25 s/^/#/' vars/basefs.yml
-- sudo apt-add-repository -y ppa:ansible/ansible
 - sudo apt-get update -q
-- sudo apt-get install -y -q ansible
+- sudo pip install ansible==1.9.4
 - sudo modprobe overlayfs
 script:
 - sudo ansible-playbook -i hosts all.yml

--- a/roles/initrd/provision_initrd/tasks/main.yml
+++ b/roles/initrd/provision_initrd/tasks/main.yml
@@ -5,6 +5,9 @@
 - name: Install initrd kernel dependencies
   apt: name=linux-image-{{ initrd_kernel_version }}
 
+- name: Install linux image extras for physical machine support
+  apt: name=linux-image-extra-{{ initrd_kernel_version }}
+
 - name: Install required packages
   apt: name="{{ item.package }}={{ item.version }}"
   with_items: initrd_package_manifest


### PR DESCRIPTION
Fixes https://github.com/RackHD/RackHD/issues/57

Apparently since Ubuntu 14.04 the main bulk of kernel drivers have been kept in the `linux-image-extras-<version>` package, so that the main `linux-image-<version>` package could be slimmed down for virtual machine images. We need to include this package in our initrd build environment so that we actually have all the required HW drivers to boot physical machines! Some of the primary ones that have been missing are usb-hid keyboard support (makes TTY1 hang, which explains partly what we've been seeing) and network device driver support.

Adding this patch increases the build size of the initrd from ~9mb to ~18mb.
