### PR TITLE
Add sysnlinux bootloader support

### DIFF
--- a/.bintray.json
+++ b/.bintray.json
@@ -18,6 +18,10 @@
             {
                 "includePattern": "/tmp/on-imagebuilder/ipxe/(.*)", "uploadPattern": "ipxe/$1",
                 "matrixParams": { "override": 1 }
+            },
+            {
+                "includePattern": "/tmp/on-imagebuilder/syslinux/(.*)", "uploadPattern": "syslinux/$1",
+                "matrixParams": { "override": 1 }
             }
         ],
     "publish": true

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ script:
 before_deploy:
 - sudo chmod 644 /tmp/on-imagebuilder/builds/*
 - sudo chmod 644 /tmp/on-imagebuilder/ipxe/*
+- sudo chmod 644 /tmp/on-imagebuilder/syslinux/*
 deploy: 
   provider: bintray
   file: .bintray.json

--- a/all.yml
+++ b/all.yml
@@ -17,3 +17,7 @@
 - include: common/ipxe_builder.yml
   vars:
     - config_file: vars/ipxe.yml
+
+- include: common/syslinux_builder.yml
+  vars:
+    - config_file: vars/syslinux.yml

--- a/common/syslinux_builder.yml
+++ b/common/syslinux_builder.yml
@@ -1,0 +1,6 @@
+---
+- hosts: build_local
+  vars_files:
+    - ../{{ config_file }}
+  roles:
+    - ../roles/syslinux

--- a/hosts
+++ b/hosts
@@ -20,6 +20,7 @@ overlayfs_work_dir=/tmp/on-imagebuilder/overlay/work
 overlayfs_build_root=/tmp/on-imagebuilder/overlay/root
 build_artifact_path=/tmp/on-imagebuilder/builds
 ipxe_build_artifact_path=/tmp/on-imagebuilder/ipxe
+syslinux_build_artifact_path=/tmp/on-imagebuilder/syslinux
 
 
 [on_imagebuild:children]

--- a/roles/ipxe/tasks/main.yml
+++ b/roles/ipxe/tasks/main.yml
@@ -62,13 +62,6 @@
          dest={{ ipxe_build_artifact_path }}/monorail.ipxe fail_on_missing=yes
          flat=yes
 
-- name: fetch the resulting files
-  fetch: src={{ ansible_env.HOME }}/ipxe/src/bin/{{ item }} 
-         dest={{ ipxe_build_artifact_path }}/{{ item }} fail_on_missing=yes
-         flat=yes
-  with_items:
-    - undionly.kpxe
-
 - name: fetch the resulting files efi 64 bit file
   fetch: src={{ ansible_env.HOME }}/ipxe/src/bin-x86_64-efi/{{ item }}
         dest={{ ipxe_build_artifact_path }}/monorail-efi64-snponly.efi fail_on_missing=yes

--- a/roles/syslinux/files/0001-Fix-compiling-failure-on-Ubuntu-14.04.patch
+++ b/roles/syslinux/files/0001-Fix-compiling-failure-on-Ubuntu-14.04.patch
@@ -1,0 +1,54 @@
+From 5136b8eb33bdd7e1ca9f9a3e649cb11ff979c350 Mon Sep 17 00:00:00 2001
+From: Andrew Hou <Andrew.Hou@emc.com>
+Date: Thu, 14 Jan 2016 11:50:48 +0800
+Subject: [PATCH] Fix compiling failure on Ubuntu 14.04
+
+1. Disable default devel config that has strict gcc 4.8.1 check on Ubuntu 14.04.3
+2. Fix new ext2_fs.h location on Ubuntu 14.04.3
+3. Apply new mingw64 tool on Ubuntu 14.04.3
+---
+ MCONFIG                   | 2 +-
+ libinstaller/linuxioctl.h | 2 +-
+ win64/find-mingw64.sh     | 1 +
+ 3 files changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/MCONFIG b/MCONFIG
+index a71fd13..b5adefa 100644
+--- a/MCONFIG
++++ b/MCONFIG
+@@ -77,7 +77,7 @@ UMAKEDEPS = -Wp,-MT,$@,-MMD,$(dir $@).$(notdir $@).d
+
+ # Items that are only appropriate during development; this file is
+ # removed when tarballs are generated.
+--include $(topdir)/MCONFIG.devel
++#-include $(topdir)/MCONFIG.devel
+
+ # Local additions, like -DDEBUG can go here
+ -include $(topdir)/MCONFIG.local
+diff --git a/libinstaller/linuxioctl.h b/libinstaller/linuxioctl.h
+index 7ef919a..100fd86 100644
+--- a/libinstaller/linuxioctl.h
++++ b/libinstaller/linuxioctl.h
+@@ -19,7 +19,7 @@
+
+ #undef SECTOR_SIZE		/* Defined in msdos_fs.h for no good reason */
+ #undef SECTOR_BITS
+-#include <linux/ext2_fs.h>	/* EXT2_IOC_* */
++#include <ext2fs/ext2_fs.h>	/* EXT2_IOC_* */
+
+ #ifndef FAT_IOCTL_GET_ATTRIBUTES
+ # define FAT_IOCTL_GET_ATTRIBUTES	_IOR('r', 0x10, __u32)
+diff --git a/win64/find-mingw64.sh b/win64/find-mingw64.sh
+index c45db56..eadaab5 100755
+--- a/win64/find-mingw64.sh
++++ b/win64/find-mingw64.sh
+@@ -4,6 +4,7 @@ cc="$1"
+
+ for prefix in \
+     mingw64- \
++    x86_64-w64-mingw32- \
+     x86_64-pc-mingw64- \
+     x86_64-pc-mingw64msvc- \
+     x86_64-pc-mingw32- \
+--
+1.9.1

--- a/roles/syslinux/tasks/main.yml
+++ b/roles/syslinux/tasks/main.yml
@@ -31,6 +31,10 @@
   apt: name=mingw-w64 state=present
   sudo: yes
 
+- name: install e2fslibs-dev
+  apt: name=e2fslibs-dev state=present
+  sudo: yes
+
 - name: check out syslinux source repository
   git:  repo=https://git.kernel.org/pub/scm/boot/syslinux/syslinux.git
         dest="{{ ansible_env.HOME }}/syslinux"

--- a/roles/syslinux/tasks/main.yml
+++ b/roles/syslinux/tasks/main.yml
@@ -1,0 +1,62 @@
+---
+- name: install git
+  apt: name=git state=present
+  sudo: yes
+
+- name: install binutils
+  apt: name=binutils-dev state=present
+  sudo: yes
+
+- name: install mktemp
+  apt: name=mktemp state=present
+  sudo: yes
+
+- name: install mtools
+  apt: name=mtools state=present
+  sudo: yes
+
+- name: install nasm
+  apt: name=nasm state=present
+  sudo: yes
+
+- name: install perl
+  apt: name=perl state=present
+  sudo: yes
+
+- name: install mingw32
+  apt: name=mingw32-binutils state=present
+  sudo: yes
+
+- name: install mingw-w64
+  apt: name=mingw-w64 state=present
+  sudo: yes
+
+- name: check out syslinux source repository
+  git:  repo=https://git.kernel.org/pub/scm/boot/syslinux/syslinux.git
+        dest="{{ ansible_env.HOME }}/syslinux"
+        force=yes accept_hostkey=yes
+        version={{ gittag }}
+
+- name: apply syslinux patch
+  patch: >
+        src=0001-Fix-compiling-failure-on-Ubuntu-14.04.patch
+        basedir="{{ ansible_env.HOME }}/syslinux"
+        strip=1
+  when: ansible_distribution == "Ubuntu" and ansible_distribution_version | int >= 14
+
+- name: clean the build
+  command: make clean
+  args:
+    chdir: "{{ ansible_env.HOME }}/syslinux"
+
+- name: build the gpxe code
+  command: make
+  args:
+    chdir: "{{ ansible_env.HOME }}/syslinux"
+
+- name: fetching compiled files
+  fetch: src={{ ansible_env.HOME }}/syslinux/gpxe/src/bin/{{ item }}
+         dest={{ syslinux_build_artifact_path }}/{{ item }} fail_on_missing=yes
+         flat=yes
+  with_items:
+    - undionly.kkpxe

--- a/vars/syslinux.yml
+++ b/vars/syslinux.yml
@@ -1,0 +1,1 @@
+gittag: syslinux-4.04


### PR DESCRIPTION
undionly.kpxe from ipxe is not the original gPXE's undionly.kkpxe file which has been validated for installing ESXi on multiple platforms, correct it here. This will fix the chainload failure issue when installing ESXi OS

related PR:
https://github.com/RackHD/RackHD/pull/70
https://github.com/RackHD/on-http/pull/91
