### PR TITLE
Don't override build to 3.13 kernel in travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: bash
 sudo: required
 dist: trusty
 before_script:
-# Rollback to 3.13 until initrd boot issue has been resolved
-- sed -i 's/3.16.0-25-generic/3.13.0-32-generic/g' group_vars/on_imagebuild
-- sed -i '24,25 s/^/#/' vars/basefs.yml
 - sudo apt-get update -q
 - sudo pip install ansible==1.9.4
 - sudo modprobe overlayfs

--- a/vars/basefs.yml
+++ b/vars/basefs.yml
@@ -10,7 +10,7 @@ basefs_exclude_packages: "initramfs-tools,initramfs-tools-bin,busybox-initramfs,
                          grub2-common,busybox-initramfs"
 
 basefs_package_manifest:
-  - { package: "openssh-server",  version: "1:6.6p1-2ubuntu2.3" }
+  - { package: "openssh-server",  version: "1:6.6p1-2ubuntu2.4" }
   - { package: "ipmitool",        version: "1.8.13-1" }
   - { package: "curl",            version: "7.35.0-1ubuntu2.5" }
   - { package: "vim-tiny",        version: "2:7.4.052-1ubuntu3" }


### PR DESCRIPTION
(UPDATED): Merge with https://github.com/RackHD/on-tasks/pull/108

I will make a corresponding PR against on-tasks to update the bootstrap-ubuntu task for the new 3.16 default discovery images and link to it.

@jlongever @RackHD/corecommitters @heckj 
