### PR TITLE
install ansible version 1.9.4 with pip.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -72,7 +72,7 @@ Vagrant.configure(2) do |config|
   # documentation for more information about their specific syntax and use.
   config.vm.provision "shell", inline: <<-SHELL
     sudo apt-get -y install python-pip
-    sudo pip install ansible==1.9.4
+    sudo pip install "ansible~=2.0.0"
     cd /vagrant
     sudo ansible-playbook -i hosts all.yml
     # sudo apt-get update

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -71,6 +71,8 @@ Vagrant.configure(2) do |config|
   # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
   # documentation for more information about their specific syntax and use.
   config.vm.provision "shell", inline: <<-SHELL
+    sudo apt-get -y install python-pip
+    sudo pip install ansible==1.9.4
     cd /vagrant
     sudo ansible-playbook -i hosts all.yml
     # sudo apt-get update


### PR DESCRIPTION
Stock Vagrant instance comes with Ansible 1.5x installed, which doesn't play nicely with building images, so this is a quick update to accommodate that...
