### PR TITLE
refactored mount commands to never create entries into /etc/fstab

### DIFF
--- a/common/tasks/mount_overlay.yml
+++ b/common/tasks/mount_overlay.yml
@@ -1,10 +1,9 @@
 ---
+- name: Make read-only squashfs image directory
+  file: name={{ overlayfs_lower_dir }} state=directory
+
 - name: Mount read-only squashfs image
-  mount: name={{ overlayfs_lower_dir }}
-         src={{ squashfs_image_path }}
-         fstype=squashfs
-         state=mounted
-         opts="loop"
+  shell: mount -t squashfs -o loop {{ squashfs_image_path }} {{ overlayfs_lower_dir }}
 
 - name: Create overlay directories
   file: name={{ item }} state=directory
@@ -16,26 +15,14 @@
 
 - name: Mount overlayfs
   when: kernel_major | int == 3 and kernel_minor | int <= 16
-  mount: name={{ overlayfs_build_root }}
-         src=overlayfs
-         fstype=overlayfs
-         opts="rw,upperdir={{ overlayfs_upper_dir }},lowerdir={{ overlayfs_lower_dir }}"
-         state=mounted
+  shell: mount -t overlayfs -o rw,upperdir={{ overlayfs_upper_dir }},lowerdir={{ overlayfs_lower_dir }} overlayfs {{ overlayfs_build_root }}
 
 - name: Mount overlay
   when: kernel_major | int == 3 and kernel_minor | int >= 18
-  mount: name={{ overlayfs_build_root }}
-         src=overlay
-         fstype=overlay
-         opts="rw,upperdir={{ overlayfs_upper_dir }},lowerdir={{ overlayfs_lower_dir }},workdir={{ overlayfs_work_dir }}"
-         state=mounted
+  shell: mount -t overlay -o rw,upperdir={{ overlayfs_upper_dir }},lowerdir={{ overlayfs_lower_dir }},workdir={{ overlayfs_work_dir }} overlay {{ overlayfs_build_root }}
 
 - name: Bind mount to chroot environment
-  mount: name={{ overlayfs_build_root }}/{{ item }}
-         src=/{{ item }}
-         fstype=none
-         opts="bind"
-         state=mounted
+  shell: mount -o bind /{{ item }} {{ overlayfs_build_root }}/{{ item }}
   with_items:
     - proc
     - dev

--- a/common/tasks/mount_rootfs.yml
+++ b/common/tasks/mount_rootfs.yml
@@ -1,7 +1,6 @@
 ---
+- name: Make rootfs build directory path
+  file: path={{ build_root }} state=directory mode=0755
+
 - name: Mount rootfs build directory
-  mount: name={{ build_root }} 
-         src=tmpfs 
-         fstype=tmpfs 
-         opts="size={{ build_root_size }}" 
-         state=mounted
+  shell: mount -t tmpfs -o size={{ build_root_size }} tmpfs {{ build_root }}

--- a/common/tasks/unmount_rootfs.yml
+++ b/common/tasks/unmount_rootfs.yml
@@ -1,6 +1,6 @@
 ---
 - name: Unmount bind mounts in build directory
-  mount: name={{ build_root }}/{{ item }} 
+  mount: name={{ build_root }}/{{ item }}
          src=none
          fstype=none
          state=unmounted

--- a/roles/basefs/build_rootfs/tasks/build.yml
+++ b/roles/basefs/build_rootfs/tasks/build.yml
@@ -1,20 +1,22 @@
 ---
 - name: Create debian rootfs
-  command: debootstrap 
+  command: debootstrap
            --arch={{ debootstrap_arch }}
-           --variant=minbase 
-           --include={{ ansible_dependencies }} 
-           --exclude={{ basefs_exclude_packages }} 
+           --variant=minbase
+           --include={{ ansible_dependencies }}
+           --exclude={{ basefs_exclude_packages }}
            {{ debootstrap_release }}
            {{ build_root }}
            {{ debootstrap_apt_server }}
 
+- name: Make chroot environment directory paths
+  file: path={{ build_root }}/{{ item }} state=directory mode=0755
+  with_items:
+      - proc
+      - dev
+
 - name: Bind mount to chroot environment
-  mount: name={{ build_root }}/{{ item }} 
-         src=/{{ item }}
-         fstype=none
-         opts="bind"
-         state=mounted
+  shell: mount -o bind /{{ item }} {{ build_root }}/{{ item }}
   with_items:
     - proc
     - dev

--- a/roles/basefs/build_squashfs/tasks/main.yml
+++ b/roles/basefs/build_squashfs/tasks/main.yml
@@ -2,18 +2,14 @@
 - name: Unmount if existing squashfs image is mounted
   mount: name={{ overlayfs_lower_dir }}
          src={{ squashfs_image_path }}
-         fstype=squashfs 
+         fstype=squashfs
          state=unmounted
 
 - name: Create build output directory
   file: path={{ build_artifact_path }} state=directory
 
 - name: Remount build root to smaller size
-  mount: name={{ build_root }} 
-         src=tmpfs 
-         fstype=tmpfs 
-         opts="remount,size={{ build_root_build_size }}" 
-         state=mounted
+  shell: mount -t tmpfs -o remount,size={{ build_root_build_size }} tmpfs {{ build_root }}
 
 - name: Unmount bind mounts from build root
   mount: name={{ build_root }}/{{ item }}

--- a/roles/initrd/make_initrd_build_env/tasks/build.yml
+++ b/roles/initrd/make_initrd_build_env/tasks/build.yml
@@ -25,11 +25,7 @@
   with_items: repository_lists
 
 - name: Bind mount to chroot environment
-  mount: name={{ build_root }}/{{ item }}
-         src=/{{ item }}
-         fstype=none
-         opts="bind"
-         state=mounted
+  shell: mount -o bind /{{ item }} {{ build_root }}/{{ item }}
   with_items:
     - proc
     - dev


### PR DESCRIPTION
@RackHD/corecommitters @rolandpoulter @tldavies @VulpesArtificem This should resolve the issue where mount points left over from our build process would cause a system to hang on reboot.
