### PR TITLE
make builds use temp directory instead of home and always build debug images

### DIFF
--- a/hosts
+++ b/hosts
@@ -20,7 +20,9 @@ overlayfs_work_dir=/tmp/on-imagebuilder/overlay/work
 overlayfs_build_root=/tmp/on-imagebuilder/overlay/root
 build_artifact_path=/tmp/on-imagebuilder/builds
 ipxe_build_artifact_path=/tmp/on-imagebuilder/ipxe
+ipxe_build_env_path=/tmp/on-imagebuilder/ipxe_build_env
 syslinux_build_artifact_path=/tmp/on-imagebuilder/syslinux
+syslinux_build_env_path=/tmp/on-imagebuilder/syslinux_build_env
 
 
 [on_imagebuild:children]

--- a/roles/ipxe/tasks/main.yml
+++ b/roles/ipxe/tasks/main.yml
@@ -7,6 +7,10 @@
   apt: name=liblzma-dev state=present
   sudo: yes
 
+- name: install libz-dev
+  apt: name=libz-dev state=present
+  sudo: yes
+
 - name: install syslinx
   apt: name=syslinux state=present
   sudo: yes
@@ -25,67 +29,94 @@
 
 - name: check out iPXE source repository
   git:  repo=https://git.ipxe.org/ipxe.git
-        dest="{{ ansible_env.HOME }}/ipxe"
+        dest="{{ ipxe_build_env_path }}/ipxe"
         force=yes accept_hostkey=yes
         version={{ gitbranch }}
 
 - name: copy in general.h configuration file for build
-  copy: src=general.h dest="{{ ansible_env.HOME }}/ipxe/src/config/local/general.h"
+  copy: src=general.h dest="{{ ipxe_build_env_path }}/ipxe/src/config/local/general.h"
   sudo: no
 
 - name: copy in the default.ipxe script
-  copy: src=default.ipxe dest="{{ ansible_env.HOME }}/ipxe/src/default.ipxe"
+  copy: src=default.ipxe dest="{{ ipxe_build_env_path }}/ipxe/src/default.ipxe"
   sudo: no
 
+######
+# Group of ops to build our "general code", which is to say
+#  the monorail.ipxe base image. The group build boths the
+#  production monorail.ipxe, but also a couple of debug ones.
 - name: clean the build
   command: make clean
   args:
-    chdir: "{{ ansible_env.HOME }}/ipxe/src"
+    chdir: "{{ ipxe_build_env_path }}/ipxe/src"
 
 - name: build the general code
   command: make EMBED=default.ipxe
   args:
-    chdir: "{{ ansible_env.HOME }}/ipxe/src"
+    chdir: "{{ ipxe_build_env_path }}/ipxe/src"
 
+- name: fetching monorail.ipxe file
+  fetch: src={{ ipxe_build_env_path }}/ipxe/src/bin/{{ item }}
+         dest={{ ipxe_build_artifact_path }}/monorail.ipxe fail_on_missing=yes
+         flat=yes
+  with_items:
+    - ipxe.pxe
+
+# Now for a version of the same to help debug communication issues.
+- name: build the general code with communications level debug
+  command: make DEBUG=dhcp:9,tftp,config:9,netdevice bin/ipxe.pxe EMBED=default.ipxe
+  args:
+    chdir: "{{ ipxe_build_env_path }}/ipxe/src"
+
+- name: fetching monorail.ipxe.com_debug file
+  fetch: src={{ ipxe_build_env_path }}/ipxe/src/bin/{{ item }}
+         dest={{ ipxe_build_artifact_path }}/monorail.ipxe.com_debug fail_on_missing=yes
+         flat=yes
+  with_items:
+    - ipxe.pxe
+
+# Now for a version of the same to help debug more device-type issues. Note, this is called
+#  ".debug" to match existing use of .debug.
+- name: build the general code with device related issues.
+  command: make DEBUG=pci,device,intel bin/ipxe.pxe EMBED=default.ipxe
+  args:
+    chdir: "{{ ipxe_build_env_path }}/ipxe/src"
+
+- name: fetching monorail.ipxe.com_debug file
+  fetch: src={{ ipxe_build_env_path }}/ipxe/src/bin/{{ item }}
+         dest={{ ipxe_build_artifact_path }}/monorail.ipxe.debug fail_on_missing=yes
+         flat=yes
+  with_items:
+    - ipxe.pxe
+
+
+#####
+# Group of ops for EFI builds targets
 - name: disable COMBOOT in general.h for EFI builds
-  command: sed -i '3 s/^/\/\//' {{ ansible_env.HOME }}/ipxe/src/config/local/general.h
+  command: sed -i '3 s/^/\/\//' {{ ipxe_build_env_path }}/ipxe/src/config/local/general.h
+  args:
+    chdir: "{{ ipxe_build_env_path }}/ipxe/src"
 
 - name: build the general efi 64
   command: make bin-x86_64-efi/snponly.efi EMBED=default.ipxe
   args:
-    chdir: "{{ ansible_env.HOME }}/ipxe/src"
+    chdir: "{{ ipxe_build_env_path }}/ipxe/src"
 
 - name: build the general code efi 32
   command: make bin-i386-efi/snponly.efi
   args:
-    chdir: "{{ ansible_env.HOME }}/ipxe/src"
-
-- name: fetching monorail.ipxe file
-  fetch: src={{ ansible_env.HOME }}/ipxe/src/bin/ipxe.pxe
-         dest={{ ipxe_build_artifact_path }}/monorail.ipxe fail_on_missing=yes
-         flat=yes
+    chdir: "{{ ipxe_build_env_path }}/ipxe/src"
 
 - name: fetch the resulting files efi 64 bit file
-  fetch: src={{ ansible_env.HOME }}/ipxe/src/bin-x86_64-efi/{{ item }}
+  fetch: src={{ ipxe_build_env_path }}/ipxe/src/bin-x86_64-efi/{{ item }}
         dest={{ ipxe_build_artifact_path }}/monorail-efi64-snponly.efi fail_on_missing=yes
         flat=yes
   with_items:
     - snponly.efi
 
 - name: fetch the resulting efi 32 bit file
-  fetch: src={{ ansible_env.HOME }}/ipxe/src/bin-i386-efi/{{ item }}
+  fetch: src={{ ipxe_build_env_path }}/ipxe/src/bin-i386-efi/{{ item }}
         dest={{ ipxe_build_artifact_path }}/monorail-efi32-snponly.efi fail_on_missing=yes
         flat=yes
   with_items:
     - snponly.efi
-
-# - name: clean the build
-#   command: make clean
-#   args:
-#     chdir: "{{ ansible_env.HOME }}/ipxe/src"
-
-# - name: build the debug code
-#   command: make DEBUG=pci,device,intel,undinet,undionly EMBED=default.ipxe
-#   command: make DEBUG=pci,device,intel bin/intel.pxe EMBED=default.ipxe
-#   args:
-#     chdir: "{{ ansible_env.HOME }}/ipxe/src"

--- a/roles/syslinux/tasks/main.yml
+++ b/roles/syslinux/tasks/main.yml
@@ -37,29 +37,29 @@
 
 - name: check out syslinux source repository
   git:  repo=https://git.kernel.org/pub/scm/boot/syslinux/syslinux.git
-        dest="{{ ansible_env.HOME }}/syslinux"
+        dest="{{ syslinux_build_env_path }}/syslinux"
         force=yes accept_hostkey=yes
         version={{ gittag }}
 
 - name: apply syslinux patch
   patch: >
         src=0001-Fix-compiling-failure-on-Ubuntu-14.04.patch
-        basedir="{{ ansible_env.HOME }}/syslinux"
+        basedir="{{ syslinux_build_env_path }}/syslinux"
         strip=1
   when: ansible_distribution == "Ubuntu" and ansible_distribution_version | int >= 14
 
 - name: clean the build
   command: make clean
   args:
-    chdir: "{{ ansible_env.HOME }}/syslinux"
+    chdir: "{{ syslinux_build_env_path }}/syslinux"
 
 - name: build the gpxe code
   command: make
   args:
-    chdir: "{{ ansible_env.HOME }}/syslinux"
+    chdir: "{{ syslinux_build_env_path }}/syslinux"
 
 - name: fetching compiled files
-  fetch: src={{ ansible_env.HOME }}/syslinux/gpxe/src/bin/{{ item }}
+  fetch: src={{ syslinux_build_env_path }}/syslinux/gpxe/src/bin/{{ item }}
          dest={{ syslinux_build_artifact_path }}/{{ item }} fail_on_missing=yes
          flat=yes
   with_items:


### PR DESCRIPTION
Changes:
- change ipxe to use a build directory in the temp-space instead of in the users home directory
- change syslinux to use a build directory in the temp-space instead of in the users home directory
- change ipxe tasks to:
  - always build the monorail.ipxe.debug (see below for reason)
  - also build a communications style ipxe.debug. The existing one was more for pci-bus stuff vs looking at dhcp traffic debug.

a note on building the debug images. The contents of static-common has included the hand generated
debug image for awhile. However, since folk didn't know to go and uncomment-out the build for
it, it was not getting updated alongside the actual image. While it is only used in debug
cases, having the two version drift apart so much without any indication caused some
ackward issues in the field.

Using reviewer list from previous folk's PRs: @RackHD/corecommitters @rolandpoulter @tldavies @VulpesArtificem
