### PR TITLE
Update openssh-server version according to the remove Ubuntu apt server

### DIFF
--- a/vars/basefs.yml
+++ b/vars/basefs.yml
@@ -10,7 +10,7 @@ basefs_exclude_packages: "initramfs-tools,initramfs-tools-bin,busybox-initramfs,
                          grub2-common,busybox-initramfs"
 
 basefs_package_manifest:
-  - { package: "openssh-server",  version: "1:6.6p1-2ubuntu2.6" }
+  - { package: "openssh-server",  version: "1:6.6p1-2ubuntu2.7" }
   - { package: "ipmitool",        version: "1.8.13-1" }
   - { package: "curl",            version: "7.35.0-1ubuntu2.6" }
   - { package: "vim-tiny",        version: "2:7.4.052-1ubuntu3" }


### PR DESCRIPTION
according to https://travis-ci.org/RackHD/on-imagebuilder/builds/130764614

We restricted "openssh-server" with exact version of "1:6.6p1-2ubuntu2.6"
but seems the apt source version is observed as "1:6.6p1-2ubuntu2.7" now ,because the upstream repositories don't store the old one.

@benbp  @anhou 
