### PR TITLE
allow mount overlay when kernel major >= 4

### DIFF
--- a/common/tasks/mount_overlay.yml
+++ b/common/tasks/mount_overlay.yml
@@ -18,7 +18,7 @@
   shell: mount -t overlayfs -o rw,upperdir={{ overlayfs_upper_dir }},lowerdir={{ overlayfs_lower_dir }} overlayfs {{ overlayfs_build_root }}
 
 - name: Mount overlay
-  when: kernel_major | int == 3 and kernel_minor | int >= 18
+  when: kernel_major | int == 3 and kernel_minor | int >= 18 or kernel_major | int >= 4
   shell: mount -t overlay -o rw,upperdir={{ overlayfs_upper_dir }},lowerdir={{ overlayfs_lower_dir }},workdir={{ overlayfs_work_dir }} overlay {{ overlayfs_build_root }}
 
 - name: Bind mount to chroot environment

--- a/common/tasks/unmount_overlay.yml
+++ b/common/tasks/unmount_overlay.yml
@@ -22,7 +22,7 @@
          state=unmounted
 
 - name: Unmount any existing overlay
-  when: kernel_major | int == 3 and kernel_minor | int >= 18
+  when: kernel_major | int == 3 and kernel_minor | int >= 18 or kernel_major | int >= 4
   mount: name={{ overlayfs_build_root }}
          src=overlay
          fstype=overlay


### PR DESCRIPTION
Failed to build micro kernel because of the version of micro kernel.
Try to make the tasks run when kernel major >=4 and do some tests as below:
1. build micro kernel again. The build succeeded.
2. copy the static files it produced to http-static-directory and tftp-static-directory.
3. restart rackhd services.
4. deploy a virtual node.
5. try to get the id of the virtual node by API and I got it.
6. try to get the catalogs of the virtual node by API and id and I got it.
@yyscamper @anhou @iceiilin @panpan0000 @benbp 
