### PR TITLE
Build overlayfs for secure erase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 dist: trusty
 before_script:
 - sudo apt-get update -q
-- sudo pip install ansible
+- sudo pip install ansible==2.0.2.0
 - sudo modprobe overlayfs
 script:
 - sudo ./build_all.sh

--- a/build_oem.sh
+++ b/build_oem.sh
@@ -9,3 +9,9 @@ sudo ansible-playbook -i hosts common/overlay_wrapper.yml -e "config_file=vars/o
 
 # dell overlay
 sudo ansible-playbook -i hosts common/overlay_wrapper.yml -e "config_file=vars/oem/dell_raid_overlay.yml provisioner=roles/oem/overlay/provision_dell_raid_overlay"
+
+# raid overlay
+sudo ansible-playbook -i hosts common/overlay_wrapper.yml -e "config_file=vars/oem/raid_overlay.yml provisioner=roles/oem/overlay/provision_raid_overlay"
+
+# secure erase overlay
+sudo ansible-playbook -i hosts common/overlay_wrapper.yml -e "config_file=vars/oem/secure_erase_overlay.yml provisioner=roles/oem/overlay/provision_secure_erase_overlay"

--- a/roles/oem/overlay/provision_secure_erase_overlay/tasks/main.yml
+++ b/roles/oem/overlay/provision_secure_erase_overlay/tasks/main.yml
@@ -1,0 +1,29 @@
+---
+# We need to run apt-get update because /var/cache/apt/lists gets removed
+- name: Update apt cache
+  command: "apt-get update"
+
+- name: Install required packages
+  apt: name="{{ item.package }}={{ item.version }}"
+  with_items: secure_erase_overlay_package_manifest
+
+# Install perccli tools
+- name: Copy perccli package
+  copy: src="{{ playbook_dir }}/files/{{ secure_erase_overlay_perccli_package }}" dest=/opt/
+
+- name: Install perccli tools
+  command: dpkg -i /opt/{{ secure_erase_overlay_perccli_package }}
+
+- name: Remove perccli package
+  file: path=/opt/{{ secure_erase_overlay_perccli_package }} state=absent
+
+
+# Install MegaRaid tools
+- name: Copy storcli tool
+  copy: src="{{ playbook_dir }}/files/{{ secure_erase_overlay_storcli_package }}" dest=/opt/
+
+- name: Install storcli tools
+  command: dpkg -i /opt/{{ secure_erase_overlay_storcli_package }}
+
+- name: Remove storcli tool
+  file: path=/opt/{{ secure_erase_overlay_storcli_package }} state=absent

--- a/vars/oem/secure_erase_overlay.yml
+++ b/vars/oem/secure_erase_overlay.yml
@@ -1,0 +1,12 @@
+# provisioner: roles/oem/overlay/provision_raid_overlay
+
+overlayfs_archive_name: "secure.erase.overlay.cpio"
+
+secure_erase_overlay_package_manifest:
+    - { package: "sg3-utils", version: "1.36-1ubuntu1"}
+    - { package: "hdparm", version: "9.43-1ubuntu3"}
+    - { package: "coreutils", version: "8.21-1ubuntu5.4"}
+    - { package: "scrub", version: "2.5.2-2"}
+
+secure_erase_overlay_storcli_package: "storcli_1.17.08_all.deb"
+secure_erase_overlay_perccli_package: "perccli_1.11.03-2_all.deb"

--- a/vars/oem/secure_erase_overlay.yml
+++ b/vars/oem/secure_erase_overlay.yml
@@ -7,6 +7,8 @@ secure_erase_overlay_package_manifest:
     - { package: "hdparm", version: "9.43-1ubuntu3"}
     - { package: "coreutils", version: "8.21-1ubuntu5.4"}
     - { package: "scrub", version: "2.5.2-2"}
+    - { package: "lsscsi",  version: "0.27-2" }
+    - { package: "lshw",  version: "02.16-2ubuntu1.3" }
 
 secure_erase_overlay_storcli_package: "storcli_1.17.08_all.deb"
 secure_erase_overlay_perccli_package: "perccli_1.11.03-2_all.deb"


### PR DESCRIPTION
build secure erase overlayfs for RackHD secure erase functionality. it supports storcli/perccli/hdparm/sg3-utils/dd/scrub. and also supplement  build raid overlay command in build_oem.sh

Update: the latest ansible version 2.1.0.0 fail when building, continue to use version 2.0.2.0. resolve https://github.com/RackHD/RackHD/issues/244
@RackHD/corecommitters @RackHD/rackhd_dev @pengz1 @iceiilin @WangWinson 
