### PR TITLE
Upgrade node 4 in basefs

### DIFF
--- a/roles/basefs/provision_rootfs/tasks/provision.yml
+++ b/roles/basefs/provision_rootfs/tasks/provision.yml
@@ -62,6 +62,19 @@
   with_items:
     - nodejs
 
+- name: Remove extra packages in setup_4.x while installing node v4
+  apt: pkg={{ item }} state=absent
+  with_items:
+    - lsb-release
+    - dh-python
+    - libpython3-stdlib
+    - libpython3.4-minimal
+    - libpython3.4-stdlib
+    - python3
+    - python3-minimal
+    - python3.4
+    - python3.4-minimal
+
 - name: Add monorail to sudoers file
   lineinfile: dest=/etc/sudoers.d/11-monorail-user 
               line="monorail ALL=(ALL) NOPASSWD:ALL" 

--- a/roles/basefs/provision_rootfs/tasks/provision.yml
+++ b/roles/basefs/provision_rootfs/tasks/provision.yml
@@ -54,6 +54,14 @@
   apt: name="{{ item.package }}={{ item.version }}"
   with_items: basefs_package_manifest
 
+- name: Setup nodejs source for installing node v4
+  shell: curl -sL https://deb.nodesource.com/setup_4.x | bash
+
+- name: Install node v4
+  apt: pkg={{ item }} state=installed
+  with_items:
+    - nodejs
+
 - name: Add monorail to sudoers file
   lineinfile: dest=/etc/sudoers.d/11-monorail-user 
               line="monorail ALL=(ALL) NOPASSWD:ALL" 

--- a/vars/basefs.yml
+++ b/vars/basefs.yml
@@ -15,8 +15,7 @@ basefs_package_manifest:
   - { package: "curl",            version: "7.35.0-1ubuntu2.6" }
   - { package: "vim-tiny",        version: "2:7.4.052-1ubuntu3" }
   - { package: "less",            version: "458-2" }
-  - { package: "nodejs",          version: "0.10.25~dfsg2-2ubuntu1" }
-  - { package: "nodejs-legacy",   version: "0.10.25~dfsg2-2ubuntu1" }
+  - { package: "ca-certificates", version: "20160104ubuntu0.14.04.1"}
   - { package: "sudo",            version: "1.8.9p5-1ubuntu1" }
 
 basefs_extra_drivers_path: /opt/drivers


### PR DESCRIPTION
Just for PR https://github.com/RackHD/on-http/pull/352  need execSync module which is supported since 0.11. execSync could make code more simple to avoid callback traps and also avoid refactor all codes to promise, our microkernel node version is 0.10. it's old, upgrade it by the way  

@RackHD/corecommitters 
