### PR TITLE
Add linux firmware-nonfree packages

### DIFF
--- a/vars/initrd.yml
+++ b/vars/initrd.yml
@@ -10,6 +10,7 @@ initrd_build_env_exclude_packages: "grub-common,grub-gfxpayload-lists,grub-pc,\
 
 initrd_package_manifest:
   - { package: "curl", version: "7.35.0-1ubuntu2.6" }
+  - { package: "linux-firmware", version: "1.127.22"}
 
 initrd_include_binaries:
   - curl


### PR DESCRIPTION
Certain NICs like QLogic and Broadcom rely on the non-free bnx drivers, which are not included by default in the linux kernel since they are proprietary, but they still affect a bunch of people so it will be good to include them by default.

@RackHD/corecommitters @maithriAjjampura
