### PR TITLE
Bump openssh-server version

### DIFF
--- a/vars/basefs.yml
+++ b/vars/basefs.yml
@@ -10,7 +10,7 @@ basefs_exclude_packages: "initramfs-tools,initramfs-tools-bin,busybox-initramfs,
                          grub2-common,busybox-initramfs"
 
 basefs_package_manifest:
-  - { package: "openssh-server",  version: "1:6.6p1-2ubuntu2.7" }
+  - { package: "openssh-server",  version: "1:6.6p1-2ubuntu2.8" }
   - { package: "ipmitool",        version: "1.8.13-1" }
   - { package: "curl",            version: "7.35.0-1ubuntu2*" }
   - { package: "vim-tiny",        version: "2:7.4.052-1ubuntu3" }


### PR DESCRIPTION
Base image builds are failing this morning with the following:

```
[vagrant@127.0.0.1:2200] out: failed: [/tmp/on-imagebuilder/base/rootfs] (item={u'version': u'1:6.6p1-2ubuntu2.7', u'package': u'openssh-server'}) => {"cache_update_time": 0, "cache_updated": false, "failed": true, "item": {"package": "openssh-server", "version": "1:6.6p1-2ubuntu2.7"}, "msg": "'/usr/bin/apt-get -y -o \"Dpkg::Options::=--force-confdef\" -o \"Dpkg::Options::=--force-confold\"   install 'openssh-server=1:6.6p1-2ubuntu2.7'' failed: E: Version '1:6.6p1-2ubuntu2.7' for 'openssh-server' was not found\n", "stderr": "E: Version '1:6.6p1-2ubuntu2.7' for 'openssh-server' was not found\n", "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\n", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information..."]}
```

Seems upstream bumped versions and does not keep old versions in the repos.  

```
root@build01:~/on-imagebuilder# apt-cache madison openssh-server
openssh-server | 1:6.6p1-2ubuntu2.8 | http://mirrors.mozy.com/ubuntu/ trusty-security/main amd64 Packages
openssh-server | 1:6.6p1-2ubuntu2.8 | http://mirrors.mozy.com/ubuntu/ trusty-updates/main amd64 Packages
openssh-server | 1:6.6p1-2ubuntu1 | http://mirrors.mozy.com/ubuntu/ trusty/main amd64 Packages
```

This PR bumps version to `1:6.6p1-2ubuntu2.8`.
