### PR TITLE
add gdisk that contains sgdisk to installed packages for overlay

### DIFF
--- a/vars/discovery_overlay.yml
+++ b/vars/discovery_overlay.yml
@@ -12,4 +12,3 @@ discovery_overlay_package_manifest:
   - { package: "ohai",  version: "6.14.0-2" }
   - { package: "lldpd", version: "0.7.7-1"}
   - { package: "hdparm", version: "9.43-1ubuntu3"}
-  - { package: "gdisk", version: "0.8.8-1ubuntu0.1"}

--- a/vars/discovery_overlay.yml
+++ b/vars/discovery_overlay.yml
@@ -12,3 +12,4 @@ discovery_overlay_package_manifest:
   - { package: "ohai",  version: "6.14.0-2" }
   - { package: "lldpd", version: "0.7.7-1"}
   - { package: "hdparm", version: "9.43-1ubuntu3"}
+  - { package: "gdisk", version: "0.8.8-1ubuntu0.1"}

--- a/vars/oem/secure_erase_overlay.yml
+++ b/vars/oem/secure_erase_overlay.yml
@@ -9,6 +9,7 @@ secure_erase_overlay_package_manifest:
     - { package: "scrub", version: "2.5.2-2"}
     - { package: "lsscsi",  version: "0.27-2" }
     - { package: "lshw",  version: "02.16-2ubuntu1.3" }
+    - { package: "gdisk", version: "0.8.8-1ubuntu0.1"}
 
 secure_erase_overlay_storcli_package: "storcli_1.17.08_all.deb"
 secure_erase_overlay_perccli_package: "perccli_1.11.03-2_all.deb"


### PR DESCRIPTION
@RackHD/corecommitters 

this will add "gdisk" to our overlay dependencies, this package contains the "sgdisk" tool requested by this issue: https://github.com/RackHD/RackHD/issues/373

-DJ
