### PR TITLE
change BASEFS and OVERLAYFS to be full URL instead of file path

### DIFF
--- a/roles/basefs/provision_rootfs/tasks/provision.yml
+++ b/roles/basefs/provision_rootfs/tasks/provision.yml
@@ -14,10 +14,10 @@
 - name: Add monorail-micro host to /etc/hostname
   lineinfile: dest=/etc/hostname line="monorail-micro" create=yes state=present
 
-- name: Configure apt
+- name: Configure dpkg
   copy: src="{{ playbook_dir }}/files/01_nodoc" dest=/etc/dpkg/dpkg.cfg.d/01_nodoc
 
-- name: Configure dpkg
+- name: Configure apt
   copy: src="{{ playbook_dir }}/files/apt.conf" dest=/etc/apt/apt.conf
 
 - name: Add commonly used directories

--- a/roles/initrd/make_initrd_build_env/tasks/build.yml
+++ b/roles/initrd/make_initrd_build_env/tasks/build.yml
@@ -9,11 +9,11 @@
            {{ build_root }}
            {{ debootstrap_apt_server }}
 
-- name: Configure apt
+- name: Configure dpkg
   copy: src="{{ playbook_dir }}/files/01_nodoc"
         dest={{ build_root }}/etc/dpkg/dpkg.cfg.d/01_nodoc
 
-- name: Configure dpkg
+- name: Configure apt
   copy: src="{{ playbook_dir }}/files/apt.conf"
         dest={{ build_root }}/etc/apt/apt.conf
 

--- a/roles/initrd/provision_initrd/files/local
+++ b/roles/initrd/provision_initrd/files/local
@@ -103,22 +103,19 @@ mountroot()
     modprobe overlayfs
     mkdir upper lower  # upper=overlay, lower=base squashfs, mount on ${rootmnt}
     mount -t tmpfs tmpfs upper  # put overlay files into a tmpfs so they don't get blown away on switch_root
-	CB=$(cat /proc/cmdline)
-	CB="${CB##*API_CB=}"
-	CB="${CB%% *}"
-	BASEFS=$(cat /proc/cmdline)
-	BASEFS="${BASEFS##*BASEFS=}"
-	BASEFS="${BASEFS%% *}"
-	OVERLAYFS=$(cat /proc/cmdline)
-	OVERLAYFS="${OVERLAYFS##*OVERLAYFS=}"
-	OVERLAYFS="${OVERLAYFS%% *}"
-	echo "downloading squashfs from http://${CB}/${BASEFS}"
-	logger "downloading squashfs from http://${CB}/${BASEFS}"
-	curl http://${CB}/${BASEFS} -o base.squashfs.img
-    echo "downloading overlay from http://${CB}/${OVERLAYFS}"
-    logger "downloading overlay from http://${CB}/${OVERLAYFS}"
+    BASEFS=$(cat /proc/cmdline)
+    BASEFS="${BASEFS##*BASEFS=}"
+    BASEFS="${BASEFS%% *}"
+    OVERLAYFS=$(cat /proc/cmdline)
+    OVERLAYFS="${OVERLAYFS##*OVERLAYFS=}"
+    OVERLAYFS="${OVERLAYFS%% *}"
+    echo "downloading squashfs from ${BASEFS}"
+    logger "downloading squashfs from ${BASEFS}"
+    curl ${BASEFS} -o base.squashfs.img
+    echo "downloading overlay from ${OVERLAYFS}"
+    logger "downloading overlay from ${OVERLAYFS}"
     cd upper
-    curl http://${CB}/${OVERLAYFS} | gzip -d -c | cpio -i
+    curl ${OVERLAYFS} | gzip -d -c | cpio -i
     cd ..
     echo "Mounting base squashfs"
     logger "Mounting base squashfs"

--- a/roles/syslinux/tasks/main.yml
+++ b/roles/syslinux/tasks/main.yml
@@ -36,7 +36,7 @@
   sudo: yes
 
 - name: check out syslinux source repository
-  git:  repo=https://git.kernel.org/pub/scm/boot/syslinux/syslinux.git
+  git:  repo=http://git.kernel.org/pub/scm/boot/syslinux/syslinux.git
         dest="{{ syslinux_build_env_path }}/syslinux"
         force=yes accept_hostkey=yes
         version={{ gittag }}


### PR DESCRIPTION
Node discovery fails when using static file server, because basefs and overlayfs are always pulled from API_CB(api.server) rather than file.server.
The solution is to change BASEFS and OVERLAYFS to be full URL instead of file path.
- use overlayfsUri and overlayfsFile to replace overlayfs in task options
- use basefsUri and basefsFile to replace basefs in task options

https://github.com/RackHD/on-tasks/pull/356
https://github.com/RackHD/on-http/pull/492
https://github.com/RackHD/on-skupack/pull/53
https://github.com/RackHD/on-taskgraph/pull/175

@RackHD/corecommitters @iceiilin @cgx027 @panpan0000 
