### PR TITLE
support release: build debian package with version like: 1.2.3-20111012UTC-b2f2da(nigthly release) or 1.2.3(official release)

### DIFF
--- a/HWIMO-BUILD
+++ b/HWIMO-BUILD
@@ -27,9 +27,9 @@ mkdir pxe
 sudo chmod 644 /tmp/on-imagebuilder/builds/*
 sudo chmod 644 /tmp/on-imagebuilder/ipxe/*
 sudo chmod 644 /tmp/on-imagebuilder/syslinux/*
-sudo cp $output_path/builds/* common/
-sudo cp $output_path/syslinux/* pxe/
-sudo cp $output_path/ipxe/* pxe/
+cp $output_path/builds/* common/
+cp $output_path/syslinux/* pxe/
+cp $output_path/ipxe/* pxe/
 rsync -av ../debian .
 
 export DEBEMAIL="hwimo robots <hwimo@hwimo.lab.emc.com>"
@@ -39,7 +39,7 @@ export DEBFULLNAME="The HWIMO Robots"
 # compute it as below:
 if [ -z "$PKG_VERSION" ];then
     GIT_COMMIT_DATE=$(git show -s --pretty="format:%ci")
-    DATE_STRING=$(date -d "$GIT_COMMIT_DATE" -u +"%Y%m%d%H%M%SZ")
+    DATE_STRING=$(date -d "$GIT_COMMIT_DATE" -u +"%Y%m%dUTC")
 
     GIT_COMMIT_HASH=$(git show -s --pretty="format:%h")
 

--- a/HWIMO-BUILD
+++ b/HWIMO-BUILD
@@ -48,7 +48,7 @@ if [ -z "$PKG_VERSION" ];then
     PKG_VERSION="$CHANGELOG_VERSION-$DATE_STRING-$GIT_COMMIT_HASH"
 fi
 
-if [[ $PKG_VERSION =~ ^[0-9.]+$ ]];then
+if [[ $PKG_VERSION =~ ^([0-9]+\.){2}[0-9]+$ ]];then
     # If version looks like 1.2.3, the build is official build.
     # So update the distribution of changelog from "UNRELEASED" to "unstable"
     dch -r ""

--- a/HWIMO-BUILD
+++ b/HWIMO-BUILD
@@ -8,6 +8,12 @@
 set -e
 output_path=/tmp/on-imagebuilder
 
+# $1 should be a file which contains the release version.
+# For example:  PKG_VERSION=1.2.3-rc-abc...
+if [ -f "$1" ];then
+    source $1
+fi
+
 #build static files
 sudo ./build_all.sh
 
@@ -15,7 +21,7 @@ sudo ./build_all.sh
 rm -rf on-static-common*
 rm -rf packagebuild
 mkdir packagebuild
-cd packagebuild
+pushd packagebuild
 
 mkdir common
 mkdir pxe
@@ -28,19 +34,18 @@ sudo cp $output_path/builds/* common/
 sudo cp $output_path/syslinux/* pxe/
 sudo cp $output_path/ipxe/* pxe/
 rsync -av ../debian .
-#generate package version
-GITCOMMITDATE=$(git show -s --pretty="format:%ci")
-DATESTRING=$(date -d "$GITCOMMITDATE" -u +"%Y-%m-%d-%H%M%SZ")
-
-PKG_VERSION="$DATESTRING"
-if [ -n "$BUILD_NUMBER" ]
-then
-  PKG_VERSION="${PKG_VERSION}-${BUILD_NUMBER}"
-fi
 
 export DEBEMAIL="hwimo robots <hwimo@hwimo.lab.emc.com>"
 export DEBFULLNAME="The HWIMO Robots"
 
-# build files in packagebuild into a debian package 
-dch -v ${PKG_VERSION} autobuild
+if [ ! -z "$PKG_VERSION" ];then
+    if [[ $PKG_VERSION =~ ^[0-9.]+$ ]];then
+        dch -r ""
+    else
+        COMMIT_STR=`git log -n 1 --oneline`
+        dch -v $PKG_VERSION -u low $COMMIT_STR -b -m
+    fi
+fi
+
 debuild --no-lintian --no-tgz-check -us -uc
+popd

--- a/HWIMO-BUILD
+++ b/HWIMO-BUILD
@@ -1,18 +1,15 @@
 #!/bin/bash
 
-# HWIMO-BUILD
-
 #
 # Build debian package for all images created by on-imagebuilder
 #
+# Input (environment variables):
+# * PKG_VERSION: The version of debian package,
+#                such as: 1.3.1 (official release);
+#
+
 set -e
 output_path=/tmp/on-imagebuilder
-
-# $1 should be a file which contains the release version.
-# For example:  PKG_VERSION=1.2.3-rc-abc...
-if [ -f "$1" ];then
-    source $1
-fi
 
 #build static files
 sudo ./build_all.sh
@@ -38,13 +35,26 @@ rsync -av ../debian .
 export DEBEMAIL="hwimo robots <hwimo@hwimo.lab.emc.com>"
 export DEBFULLNAME="The HWIMO Robots"
 
-if [ ! -z "$PKG_VERSION" ];then
-    if [[ $PKG_VERSION =~ ^[0-9.]+$ ]];then
-        dch -r ""
-    else
-        COMMIT_STR=`git log -n 1 --oneline`
-        dch -v $PKG_VERSION -u low $COMMIT_STR -b -m
-    fi
+# If PKG_VERSION is not set as an environment variable
+# compute it as below:
+if [ -z "$PKG_VERSION" ];then
+    GIT_COMMIT_DATE=$(git show -s --pretty="format:%ci")
+    DATE_STRING=$(date -d "$GIT_COMMIT_DATE" -u +"%Y%m%d%H%M%SZ")
+
+    GIT_COMMIT_HASH=$(git show -s --pretty="format:%h")
+
+    CHANGELOG_VERSION=$(dpkg-parsechangelog --show-field Version)
+
+    PKG_VERSION="$CHANGELOG_VERSION-$DATE_STRING-$GIT_COMMIT_HASH"
+fi
+
+if [[ $PKG_VERSION =~ ^[0-9.]+$ ]];then
+    # If version looks like 1.2.3, the build is official build.
+    # So update the distribution of changelog from "UNRELEASED" to "unstable"
+    dch -r ""
+else
+    COMMIT_STR=`git log -n 1 --oneline`
+    dch -v $PKG_VERSION -u low $COMMIT_STR -b -m
 fi
 
 debuild --no-lintian --no-tgz-check -us -uc


### PR DESCRIPTION
Build debian package with version naming:
 1. for nightly build: on-imagebuilder will use version  1.2.3-commit date-commit hash, such as: 
     1.2.3-20111012UTC-b2f2da
2. for release build: on-imagebuilder will use version 1.2.3 which comes from environment variable.