### PR TITLE
update the version of vim-tiny to 2:7.4.052-1ubuntu3*

### DIFF
--- a/vars/basefs-full.yml
+++ b/vars/basefs-full.yml
@@ -14,7 +14,7 @@ basefs_package_manifest:
   - { package: "openssh-server",  version: "1:6.6p1-2ubuntu2.8" }
   - { package: "ipmitool",        version: "1.8.13-1" }
   - { package: "curl",            version: "7.35.0-1ubuntu2*" }
-  - { package: "vim-tiny",        version: "2:7.4.052-1ubuntu3" }
+  - { package: "vim-tiny",        version: "2:7.4.052-1ubuntu3*" }
   - { package: "less",            version: "458-2" }
   - { package: "ca-certificates", version: "20160104ubuntu0.14.04.1"}
   - { package: "sudo",            version: "1.8.9p5-1ubuntu1" }

--- a/vars/basefs.yml
+++ b/vars/basefs.yml
@@ -13,7 +13,7 @@ basefs_package_manifest:
   - { package: "openssh-server",  version: "1:6.6p1-2ubuntu2.8" }
   - { package: "ipmitool",        version: "1.8.13-1" }
   - { package: "curl",            version: "7.35.0-1ubuntu2*" }
-  - { package: "vim-tiny",        version: "2:7.4.052-1ubuntu3" }
+  - { package: "vim-tiny",        version: "2:7.4.052-1ubuntu3*" }
   - { package: "less",            version: "458-2" }
   - { package: "ca-certificates", version: "20160104ubuntu0.14.04.1"}
   - { package: "sudo",            version: "1.8.9p5-1ubuntu1" }


### PR DESCRIPTION
Failed to run script build_all.sh
Error message:
"stderr": "E: Unable to correct problems, you have held broken packages.\n", "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\nSome packages could not be installed. This may mean that you have\nrequested an impossible situation or if you are using the unstable\ndistribution that some required packages have not yet been created\nor been moved out of Incoming.\nThe following information may help to resolve the situation:\n\nThe following packages have unmet dependencies:\n vim-tiny : Depends: vim-common (= 2:7.4.052-1ubuntu3) but 2:7.4.052-1ubuntu3.1 is to be installed\n"
