### PR TITLE
change deb name 'on-image-common' to 'on-imagebuilder' for common

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-on-image-common (1.2.3) UNRELEASED; urgency=low
+on-imagebuilder (1.1-1) UNRELEASED; urgency=low
 
   [ Alan Wei ]
   * Initial release

--- a/debian/control
+++ b/debian/control
@@ -1,4 +1,4 @@
-Source: on-image-common
+Source: on-imagebuilder
 Section: net
 Priority: optional
 Maintainer: Joe Heck <joseph.heck@emc.com>
@@ -6,8 +6,8 @@ Build-Depends: debhelper (>= 8.0.0)
 Standards-Version: 3.9.4
 
 
-Package: on-image-common
+Package: on-imagebuilder
 Architecture: all
 Depends: ${misc:Depends}
-Description: on-image-common
+Description: on-imagebuilder
  Common microkernel files for monorail workflow engine.


### PR DESCRIPTION
Use **repo name as deb name** can give great convenience in build/release.

@panpan0000 @PengTian0 