### PR TITLE
update the version of linux-firmware to 1.127.*

### DIFF
--- a/vars/initrd.yml
+++ b/vars/initrd.yml
@@ -10,7 +10,7 @@ initrd_build_env_exclude_packages: "grub-common,grub-gfxpayload-lists,grub-pc,\
 
 initrd_package_manifest:
   - { package: "curl", version: "7.35.0-1ubuntu2*" }
-  - { package: "linux-firmware", version: "1.127.22"}
+  - { package: "linux-firmware", version: "1.127.*"}
 
 initrd_include_binaries:
   - curl


### PR DESCRIPTION
Fix: E: Version '1.127.22' for 'linux-firmware' was not found

Test:
http://rackhdci.lss.emc.com/job/BuildRelease/job/Build/job/debian-build/87/