### PR TITLE
add Dockerfile for files image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM alpine:latest
+
+# on-imagebuilder docker build just package the static files into an image.
+# So before docker build the static files must have been built and stored
+# in on-imagebuilder directory. Default folders are common and pxe.
+# You can use your own folders with
+#     docker build --build-arg common=<mysrc> ...
+# Following Dockerfile rules, the <mysrc> path must be inside the context of the build.
+
+ARG common_files=./common/*
+ARG pxe_files=./pxe/*
+
+RUN mkdir -p /RackHD/downloads
+COPY ${pxe_files} /RackHD/downloads/
+
+RUN mkdir -p /RackHD/downloads/common
+COPY ${common_files} /RackHD/downloads/common/
+
+VOLUME /RackHD/files
+
+COPY ./docker-entrypoint.sh /docker-entrypoint.sh
+
+CMD [ "/docker-entrypoint.sh" ]
+

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# Copyright 2016, EMC, Inc.
+
+# set -x
+
+cp -a -f /RackHD/downloads/* /RackHD/files/
+
+while true; do
+  date;
+  sleep 120; # 2 minutes
+  # sleep 21600; # 6 hours
+done


### PR DESCRIPTION
### Background

In docker build/docker compose up, used to build image ```rackhd/files```  with downloading static files from bintray directly, and this image don't be pushed to dockerhub.
As a result, rackhd docker images use static files without version control.
And this doesn't satisfy the needs of build/release.

### Details
 [merge order 1]
This PR add docker build for this repo, then the docker build of this repo becomes the same with other repos. This give great convenience for docker build/release.

### Attention
Like docker build in other repos, docker build just wrap files into docker images with simple scripts but not truely "build".
Because of the particularity of ```on-imagebuilder```, it's build cost too much time and resources, so ```on-imagebuilder docker build``` considers that static files have been built and just need the ```common_file``` and ```pxe_files``` folder as args.

@panpan0000 @PengTian0 

### Related PRs

* [merge order 2] modify ```docker_build.sh```script for on-imagebuilder docker build https://github.com/RackHD/on-build-config/pull/47 
* [merge order 3] modify ```docker-compose.yml``` and delete old static files docker build https://github.com/RackHD/RackHD/pull/553
skip ci
