### PR TITLE
remove packagebuild after debian build

### DIFF
--- a/HWIMO-BUILD
+++ b/HWIMO-BUILD
@@ -16,7 +16,7 @@ sudo ./build_all.sh
 
 #prepare workplace for deb build
 rm -rf on-static-common*
-rm -rf packagebuild
+sudo rm -rf packagebuild
 mkdir packagebuild
 pushd packagebuild
 
@@ -30,6 +30,7 @@ sudo chmod 644 /tmp/on-imagebuilder/syslinux/*
 cp $output_path/builds/* common/
 cp $output_path/syslinux/* pxe/
 cp $output_path/ipxe/* pxe/
+
 rsync -av ../debian .
 
 export DEBEMAIL="hwimo robots <hwimo@hwimo.lab.emc.com>"
@@ -59,3 +60,5 @@ fi
 
 debuild --no-lintian --no-tgz-check -us -uc
 popd
+
+sudo rm -rf packagebuild


### PR DESCRIPTION
Fix: 
Jenkins Job failed to delete workspace after build debian packages.
Cause:
The owner of static files under packagebuild is root.

This PR will remove packagebuild after debian build.

Test:
http://rackhdci.lss.emc.com/job/Experimental-Jobs/job/testpipeline/