### PR TITLE
[skip ci]push per merge build deb to mirror bintray

### DIFF
--- a/.bintray-deb.json.in
+++ b/.bintray-deb.json.in
@@ -2,7 +2,7 @@
     "package": {
         "name": "on-imagebuilder",
         "repo": "debian", 
-        "subject": "rackhd",
+        "subject": "rackhd-mirror",
         "vcs_url": "https://github.com/RackHD/on-imagebuilder.git",
         "licenses": ["Apache-2.0"]
     },
@@ -20,7 +20,7 @@
                 { 
                     "override": 1, 
                     "deb_distribution": "trusty",
-                    "deb_component": "#COMPONENT#",
+                    "deb_component": "staging",
                     "deb_architecture": "amd64"
                 }
             }

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,10 @@ before_deploy:
 deploy:
   - provider: bintray
     file: .bintray-deb.json
-    user: $BINTRAY_USER
-    key: $BINTRAY_KEY
+    user: $MIRROR_BINTRAY_USER
+    key: $MIRROR_BINTRAY_KEY
     on:
-      all_branches: true
-      condition: ${TRAVIS_BRANCH} == master || ${TRAVIS_BRANCH} =~ ^release\/([0-9.]+)
+      branch: master
       
   - provider: bintray
     file: .bintray-gen.json


### PR DESCRIPTION
This deb is necessary but, not verified deb shouldn't be pushed to bintray.

Fix RAC4535

@panpan0000 @PengTian0 