### PR TITLE
Fix: failed to build debian package because missing of fakeroot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ addons:
       - dh-make
       - devscripts
       - debhelper
+      - fakeroot
 before_script:
 - sudo apt-get update -q
 - sudo pip install ansible==2.0.2.0


### PR DESCRIPTION
Fix: failed to build debian package because missing of fakeroot
@anhou @iceiilin 