### PR TITLE
RAC-6168 current rancher release generates kernel warning , upgrading…

### DIFF
--- a/micro-docker/Dockerfile
+++ b/micro-docker/Dockerfile
@@ -2,12 +2,14 @@ FROM debian:jessie
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
                ipmitool \
+               python \
                curl \
                vim-tiny \
                less \
                ca-certificates \
                sudo \
                dmidecode \
+               ifupdown \
                lshw \
                lsscsi \
                pciutils \

--- a/roles/micro_docker/tasks/main.yml
+++ b/roles/micro_docker/tasks/main.yml
@@ -22,10 +22,10 @@
 
 - name: download rancherOS vmlinuz
   get_url:
-    url: https://github.com/rancher/os/releases/download/v0.5.0/vmlinuz
-    dest: "{{ build_artifact_path }}/vmlinuz-0.5.0-rancher"
+    url: https://github.com/rancher/os/releases/download/v1.0.2/vmlinuz
+    dest: "{{ build_artifact_path }}/vmlinuz-1.0.2-rancher"
 
 - name: download rancherOS initrd
   get_url:
-    url: https://github.com/rancher/os/releases/download/v0.5.0/initrd
-    dest: "{{ build_artifact_path }}/initrd-0.5.0-rancher"
+    url: https://github.com/rancher/os/releases/download/v1.0.2/initrd
+    dest: "{{ build_artifact_path }}/initrd-1.0.2-rancher"


### PR DESCRIPTION
… to 1.0.2.

        add two packages that were missing for network discovery to work : python, ifupdown.