### PR TITLE
Remove microkernel build from build_all.sh

### DIFF
--- a/HWIMO-BUILD
+++ b/HWIMO-BUILD
@@ -10,7 +10,7 @@
 
 set -e
 output_path=/tmp/on-imagebuilder
-
+bintray_repo=http://dl.bintray.com/rackhd/binary/builds
 #build static files
 sudo ./build_all.sh
 
@@ -22,6 +22,14 @@ pushd packagebuild
 
 mkdir common
 mkdir pxe
+
+#add Microkernel images from bintray
+pushd $output_path/builds/
+wget $bintray_repo/base.trusty.3.16.0-25-generic.squashfs.img
+wget $bintray_repo/discovery.overlay.cpio.gz
+wget $bintray_repo/initrd.img-3.16.0-25-generic
+wget $bintray_repo/vmlinuz-3.16.0-25-generic
+popd
 
 #copy static files
 sudo chmod 644 /tmp/on-imagebuilder/builds/*

--- a/build_all.sh
+++ b/build_all.sh
@@ -2,16 +2,16 @@
 set -e
 
 # build initrd
-sudo ansible-playbook -i hosts common/initrd_wrapper.yml -e "config_file=vars/initrd.yml provisioner=roles/initrd/provision_initrd"
+#sudo ansible-playbook -i hosts common/initrd_wrapper.yml -e "config_file=vars/initrd.yml provisioner=roles/initrd/provision_initrd"
 
 # build minbasefs
-sudo ansible-playbook -i hosts common/basefs_wrapper.yml -e "config_file=vars/basefs.yml provisioner=roles/basefs/provision_rootfs"
+#sudo ansible-playbook -i hosts common/basefs_wrapper.yml -e "config_file=vars/basefs.yml provisioner=roles/basefs/provision_rootfs"
 
 # build full basefs
-sudo ansible-playbook -i hosts common/basefs_wrapper.yml -e "config_file=vars/basefs-full.yml provisioner=roles/basefs/provision_rootfs"
+#sudo ansible-playbook -i hosts common/basefs_wrapper.yml -e "config_file=vars/basefs-full.yml provisioner=roles/basefs/provision_rootfs"
 
 # build discovery overlay
-sudo ansible-playbook -i hosts common/overlay_wrapper.yml -e "config_file=vars/discovery_overlay.yml provisioner=roles/overlay/provision_discovery_overlay"
+#sudo ansible-playbook -i hosts common/overlay_wrapper.yml -e "config_file=vars/discovery_overlay.yml provisioner=roles/overlay/provision_discovery_overlay"
 
 # build micro-docker
 sudo ansible-playbook -i hosts common/docker_builder.yml


### PR DESCRIPTION
- Currently we still need old mikrokernel image for other workflows like shell-command
  in this commit, we download the microkernel from bintray instead of building it locally