### PR TITLE
RAC-6184: clear /tmp/on-imagebuilder before building debian packages

### DIFF
--- a/HWIMO-BUILD
+++ b/HWIMO-BUILD
@@ -10,6 +10,8 @@
 
 set -e
 output_path=/tmp/on-imagebuilder
+rm -rf $output_path
+mkdir -p $output_path
 bintray_repo=http://dl.bintray.com/rackhd/binary/builds
 #build static files
 sudo ./build_all.sh


### PR DESCRIPTION
Master CI #379 was red due to publish deb to Bintray problem.
The Bintray upload size limit per file is 250MB
But the new on-imagebuilder.deb size is 387MB
So Bintray upload script failed.

Root cause:
The old images under /tmp/on-imagebuilder is not clear before building debian packages.
That leads to the duplicate images packed in debian packages.

@keedya @anhou @panpan0000 

Test:
I ran the HWIMO-BUILD locally and the size of debian package is 186MB 