### PR TITLE
Update bootstrap docker image to Debian stretch

### DIFF
--- a/micro-docker/Dockerfile
+++ b/micro-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian:stretch
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
                ipmitool \


### PR DESCRIPTION
stretch has the latest IPMItool
the debian package list for stretch can be found at: https://packages.debian.org/stretch/allpackages