### PR TITLE
upgrade RancherOS to v1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Overview
 
 ### Bootstrap process
 
-The docker images produced by these scripts are intended to be netbooted and run in RAM.
+The images produced by these scripts are intended to be netbooted and run in RAM.
 The typical flow for how these images are used/booted is this:
 
 - Netboot `RacherOS`(kernel and initrd) via PXE/iPXE

--- a/build_all.sh
+++ b/build_all.sh
@@ -4,7 +4,7 @@ set -e
 BUILD_ARTIFACT_PATH=/tmp/on-imagebuilder/builds
 IPXE_BUILD_ARTIFACT_PATH=/tmp/on-imagebuilder/ipxe
 SYSLINUX_BUILD_ARTIFACT_PATH=/tmp/on-imagebuilder/syslinux
-RANCHER_VERSION=1.0.2
+RANCHER_VERSION=1.2.0
 
 mkdir -p $BUILD_ARTIFACT_PATH
 mkdir -p $IPXE_BUILD_ARTIFACT_PATH


### PR DESCRIPTION
**Background**

There are some critical bugs in previous RancherOS, e.g. https://github.com/rancher/os/issues/2144
https://rackhd.atlassian.net/browse/RAC-6646

**Done**

upgrade RancherOS to 1.2.0

@RackHD/corecommitters @keedya @pengz1 